### PR TITLE
feat: Crowdin OAuth

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -2,7 +2,6 @@ name: Basic CI
 
 env:
   CLIENT_ID: ${{ secrets.CLIENT_ID }} #OAuth app client id
-  CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }} #OAuth app client secret
 
 on:
   pull_request:

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -1,5 +1,9 @@
 name: Basic CI
 
+env:
+  CLIENT_ID: ${{ secrets.CLIENT_ID }} #OAuth app client id
+  CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }} #OAuth app client secret
+
 on:
   pull_request:
     branches: [ "master" ]

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -1,7 +1,7 @@
 name: Basic CI
 
 env:
-  CLIENT_ID: ${{ secrets.CLIENT_ID }} #OAuth app client id
+  CLIENT_ID: ${{ secrets.CLIENT_ID }} # OAuth app client id
 
 on:
   pull_request:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     types: [released]
 
 env:
-  CLIENT_ID: ${{ secrets.CLIENT_ID }} #OAuth app client id
+  CLIENT_ID: ${{ secrets.CLIENT_ID }} # OAuth app client id
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,6 @@ on:
 
 env:
   CLIENT_ID: ${{ secrets.CLIENT_ID }} #OAuth app client id
-  CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }} #OAuth app client secret
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [released]
 
+env:
+  CLIENT_ID: ${{ secrets.CLIENT_ID }} #OAuth app client id
+  CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }} #OAuth app client secret
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .vscode-test/
 *.vsix
 .idea
+local.env

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ To work with the plugin in the Visual Studio Code workspace, there should be a C
 Configuration file example:
 
 ```yaml
-"project_id": "projectId"
-"api_token": "apiToken"
+"project_id": "projectId" //optional
+"api_token": "apiToken" //optional
 "base_path": "folder" // optional
 "branch": "master" // optional
 "base_url": "https://{organization-name}.crowdin.com" // optional (for Crowdin Enterprise only)
@@ -105,6 +105,25 @@ The project ID can be found in Tools > API on your Crowdin project page.
 To generate a new API token in Crowdin, go to your Account Settings.
 
 ## Setup
+
+### OAuth
+
+1. Install the *Crowdin* plugin using one of the following methods:
+    * open VS Code Extensions (**Ctrl+Shift+X**), search for *Crowdin* and click **Install**
+
+      or
+
+    * launch VS Code Quick Open (**Ctrl+P**), paste the below command, and press **Enter**
+        ```
+        ext install Crowdin.vscode-crowdin
+        ```
+2. Run the following [commands](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette) to prepare workspace:
+    * `Crowdin: Sign In` to login into your Crowdin profile
+    * `Crowdin: Select Project` to select Crowdin project
+    * `Crowdin: Create configuration` to generate Crowdin configuration file
+      * Edit `files` according to your project needs
+
+### Manual
 
 1. Prepare a `crowdin.yml` or `crowdin.yaml` configuration file and add it to the needed workspace in Visual Studio Code.
 2. Install the *Crowdin* plugin using one of the following methods:

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ To work with the plugin in the Visual Studio Code workspace, there should be a C
 Configuration file example:
 
 ```yaml
-"project_id": "projectId" //optional
-"api_token": "apiToken" //optional
+"project_id": "projectId" // optional
+"api_token": "apiToken" // optional
 "base_path": "folder" // optional
 "branch": "master" // optional
 "base_url": "https://{organization-name}.crowdin.com" // optional (for Crowdin Enterprise only)
@@ -106,50 +106,45 @@ To generate a new API token in Crowdin, go to your Account Settings.
 
 ## Setup
 
-### OAuth
+### Installation
 
-1. Install the *Crowdin* plugin using one of the following methods:
-    * open VS Code Extensions (**Ctrl+Shift+X**), search for *Crowdin* and click **Install**
+Install the *Crowdin* plugin using one of the following methods:
 
-      or
+- open VS Code Extensions (**Ctrl+Shift+X**), search for *Crowdin* and click **Install**
 
-    * launch VS Code Quick Open (**Ctrl+P**), paste the below command, and press **Enter**
+     or
+
+- launch VS Code Quick Open (**Ctrl+P**), paste the below command, and press **Enter**
         ```
         ext install Crowdin.vscode-crowdin
         ```
-2. Run the following [commands](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette) to prepare workspace:
-    * `Crowdin: Sign In` to login into your Crowdin profile
-    * `Crowdin: Select Project` to select Crowdin project
-    * `Crowdin: Create configuration` to generate Crowdin configuration file
-      * Edit `files` according to your project needs
+
+### OAuth
+
+Run the following [commands](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette) to prepare workspace:
+
+- `Crowdin: Sign In` to login into your Crowdin profile
+- `Crowdin: Select Project` to select Crowdin project
+- `Crowdin: Create configuration` to generate Crowdin configuration file
+  - Edit `files` according to your project needs
 
 ### Manual
 
 1. Prepare a `crowdin.yml` or `crowdin.yaml` configuration file and add it to the needed workspace in Visual Studio Code.
-2. Install the *Crowdin* plugin using one of the following methods:
-    * open VS Code Extensions (**Ctrl+Shift+X**), search for *Crowdin* and click **Install**
-
-      or
-
-    * launch VS Code Quick Open (**Ctrl+P**), paste the below command, and press **Enter**
-        ```
-        ext install Crowdin.vscode-crowdin
-        ```
-
-3. The *Crowdin* plugin scans each Visual Studio Code workspace to find a Crowdin configuration file (*crowdin.yml* or *crowdin.yaml*). It automatically builds the tree with source files in the *Crowdin Explorer* component available in your Activity Bar.
-4. Use upward and downward arrows in the *Crowdin Explorer* component to upload source files to Crowdin and download translations correspondingly.
+2. The *Crowdin* plugin scans each Visual Studio Code workspace to find a Crowdin configuration file (*crowdin.yml* or *crowdin.yaml*). It automatically builds the tree with source files in the *Crowdin Explorer* component available in your Activity Bar.
+3. Use upward and downward arrows in the *Crowdin Explorer* component to upload source files to Crowdin and download translations correspondingly.
 
 ## Extension Settings
 
 This extension contributes the following settings:
 
-* `crowdin.autoRefresh`: enable/disable auto refresh of the file tree after each change in the Crowdin configuration file
+- `crowdin.autoRefresh`: enable/disable auto refresh of the file tree after each change in the Crowdin configuration file
 
-* `crowdin.stringsCompletion`: enable/disable autocompletion of strings keys
+- `crowdin.stringsCompletion`: enable/disable autocompletion of strings keys
 
-* `crowdin.stringsCompletionFileExtensions`: Comma-separated list of file extensions for which autocomplete should be active. By default, strings autocomplete will be active in all files
+- `crowdin.stringsCompletionFileExtensions`: Comma-separated list of file extensions for which autocomplete should be active. By default, strings autocomplete will be active in all files
 
-* `crowdin.useGitBranch`: enable/disable the use of a Git branch as a Crowdin branch.
+- `crowdin.useGitBranch`: enable/disable the use of a Git branch as a Crowdin branch.
 
 ## Known Issues
 
@@ -166,6 +161,7 @@ Need help working with Crowdin Visual Studio Code Plugin or have any questions? 
 We are happy to accept contributions to the Crowdin Visual Studio Code Plugin. If you want to contribute, please read the [Contributing](/CONTRIBUTING.md) guidelines.
 
 ## License
+
 <pre>
 The Crowdin Visual Studio Code Plugin is licensed under the MIT License.
 See the LICENSE file distributed with this work for additional

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,10 @@
 			"dependencies": {
 				"@crowdin/crowdin-api-client": "1.25.0",
 				"adm-zip": "^0.5.10",
+				"axios": "^1.5.1",
 				"glob": "^7.1.4",
 				"original-fs": "^1.2.0",
+				"uuid": "^9.0.1",
 				"yaml": "^2.3.2"
 			},
 			"devDependencies": {
@@ -20,7 +22,8 @@
 				"@types/glob": "^8.1.0",
 				"@types/mocha": "^10.0.2",
 				"@types/node": "^18.18.4",
-				"@types/vscode": "1.35.0",
+				"@types/uuid": "^9.0.6",
+				"@types/vscode": "1.66.0",
 				"@types/yaml": "^1.9.6",
 				"@typescript-eslint/eslint-plugin": "^5.62.0",
 				"@typescript-eslint/parser": "^5.62.0",
@@ -33,7 +36,7 @@
 				"webpack-cli": "5.1.4"
 			},
 			"engines": {
-				"vscode": "^1.35.0"
+				"vscode": "^1.66.0"
 			}
 		},
 		"node_modules/@crowdin/crowdin-api-client": {
@@ -347,10 +350,16 @@
 			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
 			"dev": true
 		},
+		"node_modules/@types/uuid": {
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.6.tgz",
+			"integrity": "sha512-BT2Krtx4xaO6iwzwMFUYvWBWkV2pr37zD68Vmp1CDV196MzczBRxuEpD6Pr395HAgebC/co7hOphs53r8V7jew==",
+			"dev": true
+		},
 		"node_modules/@types/vscode": {
-			"version": "1.35.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.35.0.tgz",
-			"integrity": "sha512-Iyliuu8Hv4qy4TEaevQzChh9UsTEcuaKdcHXBbvJnoJSF5Td2yNENOrPK+vuOaXJJBhQZb4BNJKOxt6caaQR8A==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.66.0.tgz",
+			"integrity": "sha512-ZfJck4M7nrGasfs4A4YbUoxis3Vu24cETw3DERsNYtDZmYSYtk6ljKexKFKhImO/ZmY6ZMsmegu2FPkXoUFImA==",
 			"dev": true
 		},
 		"node_modules/@types/yaml": {
@@ -890,9 +899,9 @@
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
 		},
 		"node_modules/axios": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
-			"integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
+			"integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
 			"dependencies": {
 				"follow-redirects": "^1.15.0",
 				"form-data": "^4.0.0",
@@ -3446,6 +3455,18 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true
 		},
+		"node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
 		"node_modules/watchpack": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -4014,10 +4035,16 @@
 			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
 			"dev": true
 		},
+		"@types/uuid": {
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.6.tgz",
+			"integrity": "sha512-BT2Krtx4xaO6iwzwMFUYvWBWkV2pr37zD68Vmp1CDV196MzczBRxuEpD6Pr395HAgebC/co7hOphs53r8V7jew==",
+			"dev": true
+		},
 		"@types/vscode": {
-			"version": "1.35.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.35.0.tgz",
-			"integrity": "sha512-Iyliuu8Hv4qy4TEaevQzChh9UsTEcuaKdcHXBbvJnoJSF5Td2yNENOrPK+vuOaXJJBhQZb4BNJKOxt6caaQR8A==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.66.0.tgz",
+			"integrity": "sha512-ZfJck4M7nrGasfs4A4YbUoxis3Vu24cETw3DERsNYtDZmYSYtk6ljKexKFKhImO/ZmY6ZMsmegu2FPkXoUFImA==",
 			"dev": true
 		},
 		"@types/yaml": {
@@ -4407,9 +4434,9 @@
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
 		},
 		"axios": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
-			"integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
+			"integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
 			"requires": {
 				"follow-redirects": "^1.15.0",
 				"form-data": "^4.0.0",
@@ -6294,6 +6321,11 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true
+		},
+		"uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
 		},
 		"watchpack": {
 			"version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"version": "1.5.1",
 	"license": "MIT",
 	"engines": {
-		"vscode": "^1.35.0"
+		"vscode": "^1.66.0"
 	},
 	"categories": [
 		"Other"
@@ -78,6 +78,26 @@
 			]
 		},
 		"commands": [
+			{
+				"command": "crowdin.signIn",
+				"title": "Sign in",
+				"category": "Crowdin"
+			},
+			{
+				"command": "crowdin.signOut",
+				"title": "Sign out",
+				"category": "Crowdin"
+			},
+			{
+				"command": "crowdin.selectProject",
+				"title": "Select Project",
+				"category": "Crowdin"
+			},
+			{
+				"command": "crowdin.test",
+				"title": "View Project",
+				"category": "Crowdin"
+			},
 			{
 				"command": "config.create",
 				"title": "Create configuration",
@@ -250,23 +270,26 @@
 		"@types/glob": "^8.1.0",
 		"@types/mocha": "^10.0.2",
 		"@types/node": "^18.18.4",
-		"@types/vscode": "1.35.0",
+		"@types/uuid": "^9.0.6",
+		"@types/vscode": "1.66.0",
 		"@types/yaml": "^1.9.6",
 		"@typescript-eslint/eslint-plugin": "^5.62.0",
 		"@typescript-eslint/parser": "^5.62.0",
+		"@vscode/test-electron": "2.3.5",
 		"mocha": "^10.2.0",
 		"prettier": "2.8.8",
 		"ts-loader": "9.5.0",
 		"typescript": "^5.2.2",
-		"@vscode/test-electron": "2.3.5",
 		"webpack": "5.88.2",
 		"webpack-cli": "5.1.4"
 	},
 	"dependencies": {
 		"@crowdin/crowdin-api-client": "1.25.0",
 		"adm-zip": "^0.5.10",
+		"axios": "^1.5.1",
 		"glob": "^7.1.4",
 		"original-fs": "^1.2.0",
+		"uuid": "^9.0.1",
 		"yaml": "^2.3.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -94,11 +94,6 @@
 				"category": "Crowdin"
 			},
 			{
-				"command": "crowdin.test",
-				"title": "View Project",
-				"category": "Crowdin"
-			},
-			{
 				"command": "config.create",
 				"title": "Create configuration",
 				"category": "Crowdin"

--- a/package.json
+++ b/package.json
@@ -243,6 +243,24 @@
 					"when": "view == files && viewItem == file",
 					"group": "inline@4"
 				}
+			],
+			"commandPalette": [
+				{
+					"command": "crowdin.signIn",
+					"when": "!crowdinAuthenticated"
+				},
+				{
+					"command": "crowdin.signOut",
+					"when": "crowdinAuthenticated"
+				},
+				{
+					"command": "config.create",
+					"when": "!crowdinConfigExists"
+				},
+				{
+					"command": "config.open",
+					"when": "crowdinConfigExists"
+				}
 			]
 		}
 	},

--- a/src/config/configProvider.ts
+++ b/src/config/configProvider.ts
@@ -13,8 +13,7 @@ const asyncFileExists = util.promisify(fs.exists);
 const asyncWriteFile = util.promisify(fs.writeFile);
 const asyncReadFile = util.promisify(fs.readFile);
 
-const DEFAULT_CONFIG = `
-"files": [
+const DEFAULT_CONFIG = `"files": [
   {
     "source": "",
     "translation": ""

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,9 @@ export class Constants {
     static readonly REFRESH_COMMAND = 'files.refresh';
     static readonly UPDATE_SOURCE_FOLDER_COMMAND = 'files.updateSourceFolder';
     static readonly UPDATE_SOURCE_FILE_COMMAND = 'files.updateSourceFile';
+    static readonly SIGN_IN_COMMAND = 'crowdin.signIn';
+    static readonly SIGN_OUT_COMMAND = 'crowdin.signOut';
+    static readonly SELECT_PROJECT_COMMAND = 'crowdin.selectProject';
     //properties
     static readonly AUTO_REFRESH_PROPERTY = 'crowdin.autoRefresh';
     static readonly STRINGS_COMPLETION_PROPERTY = 'crowdin.stringsCompletion';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { ConfigProvider } from './config/configProvider';
 import { Constants } from './constants';
+import * as OAuth from './oauth';
 import { StringsAutocompleteProvider } from './plugin/autocomplete/stringsAutocompleteProvider';
 import { CrowdinConfigHolder } from './plugin/crowdinConfigHolder';
 import { FilesProvider } from './plugin/files/filesProvider';
@@ -10,6 +11,7 @@ import { CommonUtil } from './util/commonUtil';
 
 export function activate(context: vscode.ExtensionContext) {
     Constants.initialize(context);
+    OAuth.initialize(context);
 
     const configHolder = new CrowdinConfigHolder();
     const filesProvider = new FilesProvider(configHolder);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,6 @@ import { CommonUtil } from './util/commonUtil';
 
 export function activate(context: vscode.ExtensionContext) {
     Constants.initialize(context);
-    OAuth.initialize(context);
 
     const configHolder = new CrowdinConfigHolder();
     const filesProvider = new FilesProvider(configHolder);
@@ -20,6 +19,8 @@ export function activate(context: vscode.ExtensionContext) {
     configHolder.addListener(() => progressProvider.refresh());
     configHolder.addListener(setConfigExists);
     configHolder.load();
+
+    OAuth.initialize(context, () => configHolder.reload());
 
     setConfigExists();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -104,12 +104,12 @@ export function activate(context: vscode.ExtensionContext) {
 function setConfigExists() {
     const workspace = CommonUtil.getWorkspace();
     if (workspace) {
-        new ConfigProvider(workspace).getFile().then(file => {
+        new ConfigProvider(workspace).getFile().then((file) => {
             if (file) {
                 vscode.commands.executeCommand('setContext', 'crowdinConfigExists', true);
             } else {
                 vscode.commands.executeCommand('setContext', 'crowdinConfigExists', false);
             }
-        })
+        });
     }
 }

--- a/src/oauth/constants.ts
+++ b/src/oauth/constants.ts
@@ -1,0 +1,6 @@
+export const CLIENT_ID = process.env.CLIENT_ID || '';
+export const CLIENT_SECRET = process.env.CLIENT_SECRET || '';
+export const ORGANIZATION = process.env.ORGANIZATION;
+
+export const AUTH_TYPE = `crowdin-oauth`;
+export const SCOPES = ['project', 'user'];

--- a/src/oauth/constants.ts
+++ b/src/oauth/constants.ts
@@ -1,6 +1,4 @@
 export const CLIENT_ID = process.env.CLIENT_ID || '';
-export const CLIENT_SECRET = process.env.CLIENT_SECRET || '';
-export const ORGANIZATION = process.env.ORGANIZATION;
 
 export const AUTH_TYPE = `crowdin-oauth`;
-export const SCOPES = ['project', 'user'];
+export const SCOPES = ['project'];

--- a/src/oauth/crowdin.ts
+++ b/src/oauth/crowdin.ts
@@ -1,0 +1,43 @@
+import Crowdin from '@crowdin/crowdin-api-client';
+import axios from 'axios';
+import * as vscode from 'vscode';
+import { AUTH_TYPE, CLIENT_ID, CLIENT_SECRET, ORGANIZATION, SCOPES } from './constants';
+
+interface CrowdinToken {
+    accessToken: string;
+    refreshToken: string;
+    expireAt: number;
+}
+
+export async function getClient(token?: CrowdinToken): Promise<Crowdin | undefined> {
+    if (token) {
+        return new Crowdin({ token: token.accessToken, organization: ORGANIZATION });
+    }
+
+    const session = await vscode.authentication.getSession(AUTH_TYPE, SCOPES, { createIfNone: false });
+
+    if (!session) {
+        return;
+    }
+
+    const creds = JSON.parse(session.accessToken) as CrowdinToken;
+    //TODO check for expiration
+    return new Crowdin({ token: creds.accessToken, organization: ORGANIZATION });
+}
+
+export async function getToken(code: string, redirectUri: string): Promise<CrowdinToken> {
+    const resp = await axios.post('https://accounts.crowdin.com/oauth/token', {
+        grant_type: 'authorization_code',
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET,
+        redirect_uri: redirectUri,
+        code,
+    });
+
+    const { access_token, expires_in, refresh_token } = resp.data;
+    return {
+        accessToken: access_token,
+        refreshToken: refresh_token,
+        expireAt: Date.now() + expires_in * 1000,
+    };
+}

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -4,7 +4,7 @@ import { AUTH_TYPE, SCOPES } from './constants';
 import { CrowdinAuthenticationProvider } from './provider';
 import { clearProject, selectProject } from './selectProject';
 
-export function initialize(context: vscode.ExtensionContext) {
+export function initialize(context: vscode.ExtensionContext, onProjectSelected: () => Promise<void>) {
     const subscriptions = context.subscriptions;
 
     const provider = new CrowdinAuthenticationProvider(context);
@@ -36,7 +36,10 @@ export function initialize(context: vscode.ExtensionContext) {
 
     subscriptions.push(vscode.authentication.onDidChangeSessions(async (e) => getSession()));
 
-    subscriptions.push(vscode.commands.registerCommand(Constants.SELECT_PROJECT_COMMAND, () => selectProject()));
+    subscriptions.push(vscode.commands.registerCommand(Constants.SELECT_PROJECT_COMMAND, async () => {
+        await selectProject();
+        await onProjectSelected();
+    }));
 }
 
 const getSession = async () => {

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -10,13 +10,10 @@ export function initialize(context: vscode.ExtensionContext) {
     const provider = new CrowdinAuthenticationProvider(context);
 
     subscriptions.push(
-        vscode.commands.registerCommand(
-            Constants.SIGN_IN_COMMAND,
-            async () => {
-                await vscode.authentication.getSession(AUTH_TYPE, SCOPES, { createIfNone: true });
-                await vscode.commands.executeCommand('setContext', 'crowdinAuthenticated', true);
-            }
-        )
+        vscode.commands.registerCommand(Constants.SIGN_IN_COMMAND, async () => {
+            await vscode.authentication.getSession(AUTH_TYPE, SCOPES, { createIfNone: true });
+            await vscode.commands.executeCommand('setContext', 'crowdinAuthenticated', true);
+        })
     );
 
     subscriptions.push(

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -12,7 +12,10 @@ export function initialize(context: vscode.ExtensionContext) {
     subscriptions.push(
         vscode.commands.registerCommand(
             Constants.SIGN_IN_COMMAND,
-            async () => await vscode.authentication.getSession(AUTH_TYPE, SCOPES, { createIfNone: true })
+            async () => {
+                await vscode.authentication.getSession(AUTH_TYPE, SCOPES, { createIfNone: true });
+                await vscode.commands.executeCommand('setContext', 'crowdinAuthenticated', true);
+            }
         )
     );
 
@@ -25,6 +28,7 @@ export function initialize(context: vscode.ExtensionContext) {
             }
             await provider.removeSession(session.id);
             await clearProject();
+            await vscode.commands.executeCommand('setContext', 'crowdinAuthenticated', false);
             vscode.window.showInformationMessage('You successfully logged out');
         })
     );
@@ -41,6 +45,9 @@ export function initialize(context: vscode.ExtensionContext) {
 const getSession = async () => {
     const session = await vscode.authentication.getSession(AUTH_TYPE, SCOPES, { createIfNone: false });
     if (session) {
+        await vscode.commands.executeCommand('setContext', 'crowdinAuthenticated', true);
         vscode.window.showInformationMessage(`Welcome back ${session.account.label}`);
+    } else {
+        await vscode.commands.executeCommand('setContext', 'crowdinAuthenticated', false);
     }
 };

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { Constants } from '../constants';
 import { AUTH_TYPE, SCOPES } from './constants';
 import { CrowdinAuthenticationProvider } from './provider';
-import { clearProject, getProject, selectProject } from './selectProject';
+import { clearProject, selectProject } from './selectProject';
 
 export function initialize(context: vscode.ExtensionContext) {
     const subscriptions = context.subscriptions;
@@ -36,18 +36,6 @@ export function initialize(context: vscode.ExtensionContext) {
     subscriptions.push(vscode.authentication.onDidChangeSessions(async (e) => getSession()));
 
     subscriptions.push(vscode.commands.registerCommand(Constants.SELECT_PROJECT_COMMAND, () => selectProject()));
-
-    //for testing
-    subscriptions.push(
-        vscode.commands.registerCommand('crowdin.test', async () => {
-            const project = await getProject();
-            if (!project) {
-                vscode.window.showInformationMessage('Project not selected');
-            } else {
-                vscode.window.showInformationMessage(`Project selected : ${project}`);
-            }
-        })
-    );
 }
 
 const getSession = async () => {

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -1,0 +1,58 @@
+import * as vscode from 'vscode';
+import { Constants } from '../constants';
+import { AUTH_TYPE, SCOPES } from './constants';
+import { CrowdinAuthenticationProvider } from './provider';
+import { clearProject, getProject, selectProject } from './selectProject';
+
+export function initialize(context: vscode.ExtensionContext) {
+    const subscriptions = context.subscriptions;
+
+    const provider = new CrowdinAuthenticationProvider(context);
+
+    subscriptions.push(
+        vscode.commands.registerCommand(
+            Constants.SIGN_IN_COMMAND,
+            async () => await vscode.authentication.getSession(AUTH_TYPE, SCOPES, { createIfNone: true })
+        )
+    );
+
+    subscriptions.push(
+        vscode.commands.registerCommand(Constants.SIGN_OUT_COMMAND, async () => {
+            const session = await vscode.authentication.getSession(AUTH_TYPE, SCOPES, { createIfNone: false });
+            if (!session) {
+                vscode.window.showWarningMessage('You are not logged in');
+                return;
+            }
+            await provider.removeSession(session.id);
+            await clearProject();
+            vscode.window.showInformationMessage('You successfully logged out');
+        })
+    );
+
+    subscriptions.push(provider);
+
+    getSession();
+
+    subscriptions.push(vscode.authentication.onDidChangeSessions(async (e) => getSession()));
+
+    subscriptions.push(vscode.commands.registerCommand(Constants.SELECT_PROJECT_COMMAND, () => selectProject()));
+
+    //for testing
+    subscriptions.push(
+        vscode.commands.registerCommand('crowdin.test', async () => {
+            const project = await getProject();
+            if (!project) {
+                vscode.window.showInformationMessage('Project not selected');
+            } else {
+                vscode.window.showInformationMessage(`Project selected : ${project}`);
+            }
+        })
+    );
+}
+
+const getSession = async () => {
+    const session = await vscode.authentication.getSession(AUTH_TYPE, SCOPES, { createIfNone: false });
+    if (session) {
+        vscode.window.showInformationMessage(`Welcome back ${session.account.label}`);
+    }
+};

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -36,10 +36,12 @@ export function initialize(context: vscode.ExtensionContext, onProjectSelected: 
 
     subscriptions.push(vscode.authentication.onDidChangeSessions(async (e) => getSession()));
 
-    subscriptions.push(vscode.commands.registerCommand(Constants.SELECT_PROJECT_COMMAND, async () => {
-        await selectProject();
-        await onProjectSelected();
-    }));
+    subscriptions.push(
+        vscode.commands.registerCommand(Constants.SELECT_PROJECT_COMMAND, async () => {
+            await selectProject();
+            await onProjectSelected();
+        })
+    );
 }
 
 const getSession = async () => {

--- a/src/oauth/provider.ts
+++ b/src/oauth/provider.ts
@@ -168,7 +168,7 @@ export class CrowdinAuthenticationProvider implements vscode.AuthenticationProvi
                 try {
                     return await Promise.race([
                         this._codeExchangePromise.promise,
-                        new Promise<CrowdinToken>((_, reject) => setTimeout(() => reject('Cancelled'), 60000)),
+                        new Promise<CrowdinToken>((_, reject) => setTimeout(() => reject('Cancelled'), 180000)),
                         promiseFromEvent<any, any>(token.onCancellationRequested, (_, __, reject) => {
                             reject('User Cancelled');
                         }).promise,

--- a/src/oauth/provider.ts
+++ b/src/oauth/provider.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid } from 'uuid';
 import * as vscode from 'vscode';
 import { AUTH_TYPE, CLIENT_ID, SCOPES } from './constants';
-import { CrowdinToken, getClient, isExpired } from './crowdin';
+import { CrowdinToken, buildToken, getClient, isExpired } from './crowdin';
 import { clearProject } from './selectProject';
 import { PromiseAdapter, promiseFromEvent } from './util';
 
@@ -190,7 +190,7 @@ export class CrowdinAuthenticationProvider implements vscode.AuthenticationProvi
         const params = new URLSearchParams(query);
         const state = params.get('state');
         const accessToken = params.get('access_token');
-        const expiresIn = params.get('expires_in');
+        const expiresIn = Number(params.get('expires_in') || 0);
 
         if (!accessToken || !expiresIn) {
             reject(new Error('Access token not found'));
@@ -203,9 +203,6 @@ export class CrowdinAuthenticationProvider implements vscode.AuthenticationProvi
             return;
         }
 
-        resolve({
-            accessToken,
-            expireAt: Date.now() + Number(expiresIn) * 1000,
-        });
+        resolve(buildToken({ accessToken, expiresIn }));
     };
 }

--- a/src/oauth/provider.ts
+++ b/src/oauth/provider.ts
@@ -1,0 +1,202 @@
+import { v4 as uuid } from 'uuid';
+import * as vscode from 'vscode';
+import { AUTH_TYPE, CLIENT_ID, SCOPES } from './constants';
+import { getClient, getToken } from './crowdin';
+import { clearProject } from './selectProject';
+import { PromiseAdapter, promiseFromEvent } from './util';
+
+class UriEventHandler extends vscode.EventEmitter<vscode.Uri> implements vscode.UriHandler {
+    public handleUri(uri: vscode.Uri) {
+        this.fire(uri);
+    }
+}
+
+const AUTH_NAME = `CrowdinOAuth`;
+const SESSIONS_SECRET_KEY = `${AUTH_TYPE}.sessions`;
+
+export class CrowdinAuthenticationProvider implements vscode.AuthenticationProvider, vscode.Disposable {
+    private _sessionChangeEmitter =
+        new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
+    private _disposable: vscode.Disposable;
+    private _codeExchangePromise:
+        | { promise: Promise<string>; cancel: vscode.EventEmitter<void>; id: string }
+        | undefined;
+    private _uriHandler = new UriEventHandler();
+
+    constructor(private readonly context: vscode.ExtensionContext) {
+        this._disposable = vscode.Disposable.from(
+            vscode.authentication.registerAuthenticationProvider(AUTH_TYPE, AUTH_NAME, this, {
+                supportsMultipleAccounts: false,
+            }),
+            vscode.window.registerUriHandler(this._uriHandler)
+        );
+    }
+
+    get onDidChangeSessions() {
+        return this._sessionChangeEmitter.event;
+    }
+
+    get redirectUri() {
+        const publisher = this.context.extension.packageJSON.publisher;
+        const name = this.context.extension.packageJSON.name;
+        return `${vscode.env.uriScheme}://${publisher}.${name}`;
+    }
+
+    /**
+     * Get the existing sessions
+     * @param scopes
+     * @returns
+     */
+    public async getSessions(): Promise<readonly vscode.AuthenticationSession[]> {
+        const allSessions = await this.context.secrets.get(SESSIONS_SECRET_KEY);
+
+        if (allSessions) {
+            return JSON.parse(allSessions) as vscode.AuthenticationSession[];
+        }
+
+        return [];
+    }
+
+    /**
+     * Create a new auth session
+     * @param scopes
+     * @returns
+     */
+    public async createSession(scopes: string[]): Promise<vscode.AuthenticationSession> {
+        try {
+            const code = await this.login(scopes);
+
+            if (!code) {
+                throw new Error(`OAuth login failure`);
+            }
+
+            const token = await getToken(code, this.redirectUri);
+
+            const client = await getClient(token);
+
+            if (!client) {
+                throw new Error('Failed to connect');
+            }
+
+            const user = await client.usersApi.getAuthenticatedUser();
+
+            const session: vscode.AuthenticationSession = {
+                id: uuid(),
+                accessToken: JSON.stringify(token),
+                account: {
+                    label: user.data.email,
+                    id: user.data.email,
+                },
+                scopes: SCOPES,
+            };
+
+            await this.context.secrets.store(SESSIONS_SECRET_KEY, JSON.stringify([session]));
+            await clearProject();
+
+            this._sessionChangeEmitter.fire({ added: [session], removed: [], changed: [] });
+
+            return session;
+        } catch (e) {
+            vscode.window.showErrorMessage(`Sign in failed: ${e}`);
+            throw e;
+        }
+    }
+
+    /**
+     * Remove an existing session
+     * @param sessionId
+     */
+    public async removeSession(sessionId: string): Promise<void> {
+        const allSessions = await this.context.secrets.get(SESSIONS_SECRET_KEY);
+        if (allSessions) {
+            let sessions = JSON.parse(allSessions) as vscode.AuthenticationSession[];
+            const sessionIdx = sessions.findIndex((s) => s.id === sessionId);
+            const session = sessions[sessionIdx];
+            sessions.splice(sessionIdx, 1);
+
+            await this.context.secrets.store(SESSIONS_SECRET_KEY, JSON.stringify(sessions));
+
+            if (session) {
+                this._sessionChangeEmitter.fire({ added: [], removed: [session], changed: [] });
+            }
+        }
+    }
+
+    /**
+     * Dispose the registered services
+     */
+    public async dispose() {
+        this._disposable.dispose();
+    }
+
+    /**
+     * Log in to Crowdin OAuth
+     */
+    private async login(scopes: string[] = []) {
+        return await vscode.window.withProgress<string>(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: 'Signing in to Crowdin...',
+                cancellable: true,
+            },
+            async (_, token) => {
+                const stateId = uuid();
+
+                const searchParams = new URLSearchParams([
+                    ['client_id', CLIENT_ID],
+                    ['redirect_uri', this.redirectUri],
+                    ['response_type', 'code'],
+                    ['state', stateId],
+                    ['scope', scopes.join(' ')],
+                ]);
+                const uri = vscode.Uri.parse(`https://accounts.crowdin.com/oauth/authorize?${searchParams.toString()}`);
+                await vscode.env.openExternal(uri);
+
+                if (!this._codeExchangePromise) {
+                    this._codeExchangePromise = {
+                        ...promiseFromEvent(this._uriHandler.event, this.handleUri()),
+                        id: stateId,
+                    };
+                }
+
+                try {
+                    return await Promise.race([
+                        this._codeExchangePromise.promise,
+                        new Promise<string>((_, reject) => setTimeout(() => reject('Cancelled'), 60000)),
+                        promiseFromEvent<any, any>(token.onCancellationRequested, (_, __, reject) => {
+                            reject('User Cancelled');
+                        }).promise,
+                    ]);
+                } finally {
+                    this._codeExchangePromise?.cancel.fire();
+                    this._codeExchangePromise = undefined;
+                }
+            }
+        );
+    }
+
+    /**
+     * Handle the redirect to VS Code (after sign in from Auth0)
+     * @param scopes
+     * @returns
+     */
+    private handleUri: () => PromiseAdapter<vscode.Uri, string> = () => async (uri, resolve, reject) => {
+        const query = decodeURIComponent(uri.query);
+        const params = new URLSearchParams(query);
+        const state = params.get('state');
+        const code = params.get('code');
+
+        if (!code) {
+            reject(new Error('Code not found'));
+            return;
+        }
+
+        // Check if it is a valid auth request started by the extension
+        if (this._codeExchangePromise?.id !== state) {
+            reject(new Error('State not found'));
+            return;
+        }
+
+        resolve(code);
+    };
+}

--- a/src/oauth/provider.ts
+++ b/src/oauth/provider.ts
@@ -54,6 +54,7 @@ export class CrowdinAuthenticationProvider implements vscode.AuthenticationProvi
             const sessions = JSON.parse(allSessions) as vscode.AuthenticationSession[];
             return sessions.filter((session) => {
                 if (isExpired(session)) {
+                    vscode.window.showWarningMessage('Crowdin session expired. Please Sign In again.');
                     this.removeSession(session.id);
                     return false;
                 }

--- a/src/oauth/selectProject.ts
+++ b/src/oauth/selectProject.ts
@@ -19,7 +19,14 @@ export async function selectProject() {
     );
 
     const project = await vscode.window.showQuickPick(
-        projects.data.map((e) => `${e.data.name} | ${e.data.id}`),
+        projects.data.map(
+            (e) =>
+                ({
+                    label: e.data.name,
+                    description: e.data.description,
+                    detail: e.data.id.toString(),
+                } as vscode.QuickPickItem)
+        ),
         {
             canPickMany: false,
             title: 'Please select a project',
@@ -31,7 +38,7 @@ export async function selectProject() {
         throw new Error('Project missing');
     }
 
-    const projectId = project.split(' | ').pop();
+    const projectId = project.detail;
 
     if (!projectId) {
         vscode.window.showErrorMessage('Please select a valid project');

--- a/src/oauth/selectProject.ts
+++ b/src/oauth/selectProject.ts
@@ -14,7 +14,7 @@ export async function selectProject() {
     }
 
     const projects = await CommonUtil.withProgress(
-        () => client.projectsGroupsApi.withFetchAll().listProjects({ hasManagerAccess: 1}),
+        () => client.projectsGroupsApi.withFetchAll().listProjects({ hasManagerAccess: 1 }),
         'Loading projects...'
     );
 

--- a/src/oauth/selectProject.ts
+++ b/src/oauth/selectProject.ts
@@ -14,7 +14,7 @@ export async function selectProject() {
     }
 
     const projects = await CommonUtil.withProgress(
-        () => client.projectsGroupsApi.withFetchAll().listProjects(),
+        () => client.projectsGroupsApi.withFetchAll().listProjects({ hasManagerAccess: 1}),
         'Loading projects...'
     );
 

--- a/src/oauth/selectProject.ts
+++ b/src/oauth/selectProject.ts
@@ -47,7 +47,7 @@ export async function selectProject() {
 
     await Constants.EXTENSION_CONTEXT.secrets.store(KEY, projectId);
 
-    vscode.window.showInformationMessage(`Project ${project} selected`);
+    vscode.window.showInformationMessage(`Project ${project.label} selected`);
 }
 
 export async function getProject() {

--- a/src/oauth/selectProject.ts
+++ b/src/oauth/selectProject.ts
@@ -1,0 +1,55 @@
+import * as vscode from 'vscode';
+import { Constants } from '../constants';
+import { CommonUtil } from '../util/commonUtil';
+import { getClient } from './crowdin';
+
+const KEY = 'crowdin.project';
+
+export async function selectProject() {
+    const client = await getClient();
+
+    if (!client) {
+        vscode.window.showErrorMessage('Please sign in to Crowdin');
+        return;
+    }
+
+    const projects = await CommonUtil.withProgress(
+        () => client.projectsGroupsApi.withFetchAll().listProjects(),
+        'Loading projects...'
+    );
+
+    const project = await vscode.window.showQuickPick(
+        projects.data.map((e) => `${e.data.name} | ${e.data.id}`),
+        {
+            canPickMany: false,
+            title: 'Please select a project',
+        }
+    );
+
+    if (!project) {
+        vscode.window.showErrorMessage('Please select a project');
+        throw new Error('Project missing');
+    }
+
+    const projectId = project.split(' | ').pop();
+
+    if (!projectId) {
+        vscode.window.showErrorMessage('Please select a valid project');
+        return;
+    }
+
+    await Constants.EXTENSION_CONTEXT.secrets.store(KEY, projectId);
+
+    vscode.window.showInformationMessage(`Project ${project} selected`);
+}
+
+export async function getProject() {
+    const projectId = await Constants.EXTENSION_CONTEXT.secrets.get(KEY);
+    if (projectId) {
+        return Number(projectId);
+    }
+}
+
+export async function clearProject() {
+    await Constants.EXTENSION_CONTEXT.secrets.delete(KEY);
+}

--- a/src/oauth/util.ts
+++ b/src/oauth/util.ts
@@ -1,0 +1,52 @@
+import { Disposable, Event, EventEmitter } from 'vscode';
+
+export interface PromiseAdapter<T, U> {
+    (value: T, resolve: (value: U | PromiseLike<U>) => void, reject: (reason: any) => void): any;
+}
+
+const passthrough = (value: any, resolve: (value?: any) => void) => resolve(value);
+
+/**
+ * Return a promise that resolves with the next emitted event, or with some future
+ * event as decided by an adapter.
+ *
+ * If specified, the adapter is a function that will be called with
+ * `(event, resolve, reject)`. It will be called once per event until it resolves or
+ * rejects.
+ *
+ * The default adapter is the passthrough function `(value, resolve) => resolve(value)`.
+ *
+ * @param event the event
+ * @param adapter controls resolution of the returned promise
+ * @returns a promise that resolves or rejects as specified by the adapter
+ */
+export function promiseFromEvent<T, U>(
+    event: Event<T>,
+    adapter: PromiseAdapter<T, U> = passthrough
+): { promise: Promise<U>; cancel: EventEmitter<void> } {
+    let subscription: Disposable;
+    let cancel = new EventEmitter<void>();
+
+    return {
+        promise: new Promise<U>((resolve, reject) => {
+            cancel.event((_) => reject('Cancelled'));
+            subscription = event((value: T) => {
+                try {
+                    Promise.resolve(adapter(value, resolve, reject)).catch(reject);
+                } catch (error) {
+                    reject(error);
+                }
+            });
+        }).then(
+            (result: U) => {
+                subscription.dispose();
+                return result;
+            },
+            (error) => {
+                subscription.dispose();
+                throw error;
+            }
+        ),
+        cancel,
+    };
+}

--- a/src/plugin/crowdinConfigHolder.ts
+++ b/src/plugin/crowdinConfigHolder.ts
@@ -53,7 +53,7 @@ export class CrowdinConfigHolder {
 
     async reload() {
         await this.load();
-        this.listeners.forEach(l => l());
+        this.listeners.forEach((l) => l());
     }
 
     private updateConfigWatchers(configFiles: string[]) {

--- a/src/plugin/crowdinConfigHolder.ts
+++ b/src/plugin/crowdinConfigHolder.ts
@@ -51,6 +51,11 @@ export class CrowdinConfigHolder {
         this.updateConfigWatchers(configFiles);
     }
 
+    async reload() {
+        await this.load();
+        this.listeners.forEach(l => l());
+    }
+
     private updateConfigWatchers(configFiles: string[]) {
         const autoRefresh = vscode.workspace.getConfiguration().get<boolean>(Constants.AUTO_REFRESH_PROPERTY);
         if (!autoRefresh) {

--- a/src/plugin/files/filesProvider.ts
+++ b/src/plugin/files/filesProvider.ts
@@ -18,8 +18,8 @@ export class FilesProvider implements vscode.TreeDataProvider<FilesTreeItem> {
     /**
      * Download translations
      */
-    download(folder?: FilesTreeItem): Promise<void> {
-        return CommonUtil.withProgress(() => {
+    download(folder?: FilesTreeItem): Promise<void[]> {
+        return CommonUtil.withProgress<void[]>(() => {
             let promises: Promise<void>[];
             if (!!folder) {
                 promises = [folder.update().catch((e) => ErrorHandler.handleError(e))];

--- a/src/util/commonUtil.ts
+++ b/src/util/commonUtil.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 
 export class CommonUtil {
     static withProgress<R>(
-        task: () => Promise<any>,
+        task: () => Promise<R>,
         title: string,
         location: vscode.ProgressLocation = vscode.ProgressLocation.Notification
     ): Promise<R> {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@
 'use strict';
 
 const path = require('path');
+const webpack = require('webpack');
 
 /**@type {import('webpack').Configuration}*/
 const config = {
@@ -30,6 +31,12 @@ const config = {
             }]
         }]
     },
+    plugins: [
+        new webpack.EnvironmentPlugin(['CLIENT_ID', 'CLIENT_SECRET']),
+        new webpack.EnvironmentPlugin({
+            ORGANIZATION: null,
+        }),
+    ]
 }
 
 module.exports = config;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,9 +32,7 @@ const config = {
         }]
     },
     plugins: [
-        new webpack.EnvironmentPlugin({
-            CLIENT_ID: null,
-        }),
+        new webpack.EnvironmentPlugin(['CLIENT_ID']),
     ]
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,9 +32,8 @@ const config = {
         }]
     },
     plugins: [
-        new webpack.EnvironmentPlugin(['CLIENT_ID', 'CLIENT_SECRET']),
         new webpack.EnvironmentPlugin({
-            ORGANIZATION: null,
+            CLIENT_ID: null,
         }),
     ]
 }


### PR DESCRIPTION
Added possibility to log in via web browser.  

Added following commands:
- `Crowdin: Sign in`
- `Crowdin: Sign out`
- `Crowdin: Select Project`

Command `Create Configuration` was reworked a bit and now generates simplified configuration file (without project and credentials as now you can use new commands to achieve this).

Now `project_id` and `api_token` are optional and won't be required if user used new commands to Sign In and select project.  
Plugin remains backward compatible and will work with old setup (via configuration file).

Also commands in command palette  will be shown only if its necessary (e,g, `Sign In` only if user is not logged in, `Create Configuration` only if it's missing).

